### PR TITLE
adding test-color

### DIFF
--- a/tokens/tokens.json
+++ b/tokens/tokens.json
@@ -618,6 +618,10 @@
       "bg": {
         "value": "{colors.indigo.200}",
         "type": "color"
+      },
+      "test-color": {
+        "value": "#faab0f",
+        "type": "color"
       }
     },
     "shadows": {


### PR DESCRIPTION
What: adding test-color (orange)
Why: Testing how figma tokens can sync with github